### PR TITLE
tinker with loads of stuff - soz

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,6 @@
-import { wrapPageElement as wrap } from './src/root-wrap'
+import React from 'react'
+import { RootWrap } from './src/root-wrap'
 
-export const wrapPageElement = wrap
+export const wrapPageElement = ({ element }) => {
+  return <RootWrap>{element}</RootWrap>
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,3 +1,6 @@
-import { wrapPageElement as wrap } from './src/root-wrap'
+import React from 'react'
+import { RootWrap } from './src/root-wrap'
 
-export const wrapPageElement = wrap
+export const wrapPageElement = ({ element }) => {
+  return <RootWrap>{element}</RootWrap>
+}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,5 +1,6 @@
 import React from 'react'
+import { Container } from 'theme-ui'
 
 export const Layout = ({ children }) => {
-  return <div style={{ backgroundColor: 'red' }}>{children}</div>
+  return <Container>{children}</Container>
 }

--- a/src/components/slider.js
+++ b/src/components/slider.js
@@ -1,23 +1,16 @@
-import React, { useState } from 'react'
+import React from 'react'
+import { Slider } from 'theme-ui'
 
-export const Slider = ({ copySizeSet }) => {
-  const [sliderValue, sliderValueSet] = useState(0)
-
+export const MrSlider = ({ copySizeSet }) => {
   const handleChange = e => {
     const { value } = e.target
-    sliderValueSet(value)
+
     copySizeSet(value)
   }
 
   return (
     <>
-      <input
-        type="range"
-        min={0}
-        max={2}
-        value={sliderValue}
-        onChange={e => handleChange(e)}
-      />
+      <Slider min={0} max={2} onChange={e => handleChange(e)} />
     </>
   )
 }

--- a/src/copy/index-short.mdx
+++ b/src/copy/index-short.mdx
@@ -6,6 +6,8 @@ import WorkShort from './work-short'
 
 <BasicsShort />
 
+<Button>Test Primary Button </Button>
+
 <WorkShort />
 
 <SkillsShort />

--- a/src/gatsby-plugin-theme-ui/index.js
+++ b/src/gatsby-plugin-theme-ui/index.js
@@ -2,16 +2,45 @@ import { future } from '@theme-ui/presets'
 
 export default {
   ...future,
-  // colors: {
-  //   text: 'black',
-  //   background: '#fff',
-  // },
-  // layout: {
-  //   sizes: {
-  //     container: 640,
-  //   },
-  // },
-  // styles: {
-  //   h1: { color: 'red' },
-  // },
+  colors: {
+    text: '#282a36',
+    background: '#ffffff',
+    primary: '#ff79c6',
+    secondary: '#8be9fd',
+    muted: '#8394ca',
+    highlight: '#50fa7b',
+    gray: '#808080',
+    accent: '#F1F8FF',
+    darken: '#323442',
+  },
+  buttons: {
+    backgroundColor: 'primary',
+  },
+
+  sizes: {
+    container: 640,
+  },
+  layout: {
+    container: {
+      p: [2, 4],
+    },
+  },
+  forms: {
+    slider: {
+      color: 'primary',
+      backgroundColor: 'darken',
+    },
+  },
+
+  styles: {
+    root: {
+      fontSize: 1,
+      fontFamily: 'body',
+      lineHeight: 'body',
+    },
+    h1: { color: 'primary' },
+    a: {
+      color: 'primary',
+    },
+  },
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import { Box } from 'theme-ui'
-import { Slider } from '../components'
+import { Box, Heading } from 'theme-ui'
+import { MrSlider } from '../components'
 import Long from '../copy/index-long'
 import Medium from '../copy/index-medium'
 import Short from '../copy/index-short'
@@ -16,8 +16,10 @@ export default () => {
 
   return (
     <Box as="main">
-      <Slider copySizeSet={copySizeSet} />
-      <h1>{copy[copySize]}</h1>
+      <MrSlider copySizeSet={copySizeSet} />
+      <Heading as="h1" variant="styles.h1">
+        {copy[copySize]}
+      </Heading>
 
       <Box
         as="article"

--- a/src/root-wrap.js
+++ b/src/root-wrap.js
@@ -1,7 +1,8 @@
-import { MDXProvider } from 'gatsby-plugin-mdx'
 import React from 'react'
+import { MDXProvider } from '@mdx-js/react'
 import { Helmet } from 'react-helmet'
 import * as themeUiComponents from 'theme-ui'
+
 import {
   Basics,
   DateDistance,
@@ -9,7 +10,7 @@ import {
   Interests,
   References,
   Skills,
-  Slider,
+  MrSlider,
   Specifics,
   WorkHeader,
 } from './components'
@@ -22,24 +23,25 @@ const components = {
   Interests,
   References,
   Skills,
-  Slider,
+  MrSlider,
   Specifics,
   WorkHeader,
   ...themeUiComponents,
 }
 
-export const wrapPageElement = ({ element }) => (
+export const RootWrap = ({ children }) => (
   <>
     <Helmet>
       <script
+        // This causes the error in console "Uncaught SyntaxError: Unexpected token '<'"
         src={`${process.env.GATSBY_FATHOM_TRACKING_URL_CV}/script.js`}
         spa="auto"
         site={process.env.GATSBY_FATHOM_TRACKING_ID_CV}
         defer
-      ></script>
+      />
     </Helmet>
     <MDXProvider components={components}>
-      <Layout>{element}</Layout>
+      <Layout>{children}</Layout>
     </MDXProvider>
   </>
 )


### PR DESCRIPTION
- Rename `RootWrap` 
- Change export method in `gatsby-browser` and `gatsby-ssr`
- Use correct `MDXProivder` from `@mdx-js/react`
- Add theme object keys
- Example usage of `<Container />` `<Heading />` and `<Slider />` + respective styles and object keys in Theme Object

There's a few options for how to do some stuff in here.

In `src/pages/index` i've mapped `<Heading as="h1" variant="styles.h1">` to `styles.h1` you don't have to do it this way you could also map it to it's default key which is `text`  `<Heading as="h1" variant="heading.h1">` but if you do that you'll need to add the `text` key and style to Theme Object...

eg

```javascript
  text: {
    heading: {
      h1: {
        color: 'secondary',
      },
    },
  },
```

Given you're using both Jsx and MDX it's probably better to just keep the typography styles all in the same place

eg

```javascript
  styles: {
    ...
    h1: { color: 'primary' },
    ...
  },

```

...or you'll end up having to create a separate const for headings and spread the styles in to both the `styles.h1` and `text.heading.h1` ... which is what i did in `gatsby-theme-terminal` ... this was before i realised there's a better way.

In `src/root-wrap` you could remove the `Layout` component and just use the `<Container>{children}</Container>` it's just one less component to have to name, manage, test etc


In `src/pages` where i've re-named `Slider` to `MrSlider` you could just use `<Slider />` from Theme UI and remove the `MrSlider` component for the sane reasons above.


On that note. Now you're using Theme UI naming stuff can be tricky. Worth checking the names of the components in Theme UI so you don't name things the same.... but my approach has been try not to make any new UI components. Most of what you'll need is already part of Theme UI, i tried to do that with `gatsby-theme-terminal` and why i described it as **zero components** theme. Here's a list of all the Theme UI components: [https://gatsby-theme-terminal.netlify.app/theme-ui-components](https://gatsby-theme-terminal.netlify.app/theme-ui-components/)

All i add in `gatsby-theme-terminal`  are what i call data components which just get data and return it, what you render using this data is up to you when you use the theme... it's how i made all the dashboard components on my [blog](https://paulie.dev/dashboard/) you can see the example "data" components [here](https://gatsby-theme-terminal.netlify.app/components/)
